### PR TITLE
Spotify Refactoring

### DIFF
--- a/app/lib/spotify.ts
+++ b/app/lib/spotify.ts
@@ -427,11 +427,10 @@ const initializeFromRequest = async (req: Request) => {
     options.refreshToken = cookie.spotify.refreshToken
   }
 
+  // Netlify forwards the country based upon geoip in the x-country header
+  // https://answers.netlify.com/t/user-location-in-headers/11937/3
   if (req.headers.get('x-country')) {
     options.country = req.headers.get('x-country') || undefined
-    console.log(
-      `setting the country to ${options.country} from the x-country header`
-    )
   }
 
   const url = new URL(req.url)

--- a/app/lib/spotify.ts
+++ b/app/lib/spotify.ts
@@ -427,8 +427,18 @@ const initializeFromRequest = async (req: Request) => {
     options.refreshToken = cookie.spotify.refreshToken
   }
 
+  if (req.headers.get('x-country')) {
+    options.country = req.headers.get('x-country') || undefined
+    console.log(
+      `setting the country to ${options.country} from the x-country header`
+    )
+  }
+
   const url = new URL(req.url)
-  options.country = url.searchParams.get('country') || undefined
+
+  if (url.searchParams.get('country')) {
+    options.country = url.searchParams.get('country') || undefined
+  }
 
   return new Spotify(options)
 }

--- a/app/lib/spotify.ts
+++ b/app/lib/spotify.ts
@@ -6,345 +6,383 @@ import random from 'lodash/random'
 import db from './db'
 import cache from './cache'
 
-const spotifyAPIFactory = () =>
-  new SpotifyWebApi({
-    clientId: process.env.SPOTIFY_CLIENT_ID,
-    clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
-    redirectUri:
-      process.env.NODE_ENV === 'production'
-        ? 'https://album-mode.party/spotify/callback'
-        : 'http://localhost:3000/spotify/callback',
-  })
-
-export const spotifyAPI = spotifyAPIFactory()
-
-const getClient = async () => {
-  // @TODO This token expires, I need to cache it with a TTL
-  if (!spotifyAPI.getAccessToken()) {
-    await spotifyAPI
-      .clientCredentialsGrant()
-      .then((data) => spotifyAPI.setAccessToken(data.body.access_token))
-  }
-
-  return spotifyAPI
+interface SpotifyOptions {
+  userAccessToken?: string | undefined
+  refreshToken?: string | undefined
+  country?: string
 }
 
-const getUserClient = (accessToken: string, refreshToken?: string) => {
-  const api = spotifyAPIFactory()
-  api.setAccessToken(accessToken)
+export class Spotify {
+  private userAccessToken: string | undefined
+  private refreshToken: string | undefined
+  private country: string | undefined
+  private api: SpotifyWebApi
+  private clientCredentialsTokenCacheKey = 'spotify-clientCredentialsToken'
 
-  if (refreshToken) {
-    api.setRefreshToken(refreshToken)
-  }
-
-  return api
-}
-
-const getRandomAlbumForLabelSlug = async (labelSlug: string) => {
-  const label = await db.getLabelBySlug(labelSlug)
-
-  if (!label) {
-    throw new Error(`Could not find label for slug '${labelSlug}'`)
-  }
-
-  return getRandomAlbumForLabel(label.name)
-}
-
-const getRandomAlbumForGroupSlug = async (groupSlug: string) => {
-  const artist = await db.getRandomArtistFromGroupSlug(groupSlug)
-
-  if (!artist) {
-    throw new Error(`Could not find artist under group slug '${groupSlug}'`)
-  }
-
-  return getRandomAlbumForSearchTerm(`artist:"${artist.name}"`)
-}
-
-const getRandomAlbumForLabel = async (label: string) =>
-  getRandomAlbumForSearchTerm(`label:"${label}"`, 500)
-
-const getRandomAlbumForArtist = async (artistName: string) => {
-  const client = await getClient()
-  const artist = await client
-    .search(`artist:"${artistName}"`, ['artist'], {
-      limit: 1,
+  constructor(options: SpotifyOptions) {
+    this.userAccessToken = options.userAccessToken
+    this.refreshToken = options.refreshToken
+    this.country = options.country ?? 'US'
+    this.api = new SpotifyWebApi({
+      clientId: process.env.SPOTIFY_CLIENT_ID,
+      clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+      redirectUri:
+        process.env.NODE_ENV === 'production'
+          ? 'https://album-mode.party/spotify/callback'
+          : 'http://localhost:3000/spotify/callback',
     })
-    .then((resp) => resp.body.artists?.items?.[0])
-
-  if (!artist) {
-    throw new Error('not found: could not find artist with that name')
   }
 
-  const firstPage = await client.getArtistAlbums(artist.id, {
-    limit: 1,
-    include_groups: 'album',
-  })
-  const offset = random(0, firstPage.body.total)
+  async getClient() {
+    if (this.userAccessToken) {
+      this.api.setAccessToken(this.userAccessToken)
 
-  if (offset === 0) {
-    return firstPage.body.items[0]
-  }
+      if (this.refreshToken) {
+        this.api.setRefreshToken(this.refreshToken)
+      }
+    } else if (!this.api.getAccessToken()) {
+      let token = cache.get<string>(this.clientCredentialsTokenCacheKey)
 
-  return client
-    .getArtistAlbums(artist.id, {
-      limit: 1,
-      offset,
-      include_groups: 'album',
-    })
-    .then((resp) => resp.body.items[0])
-}
-
-const getRandomAlbumForSearchTerm = async (
-  searchTerm: string,
-  poolLimit = 1000
-): Promise<SpotifyApi.AlbumObjectSimplified | null> => {
-  const client = await getClient()
-  const firstPage = await client.search(searchTerm, ['album'], {
-    limit: 1,
-  })
-
-  if (!firstPage.body.albums?.total) {
-    throw new Error('could not fetch first page of albums search term')
-  }
-
-  const albumOffsetToFetch = random(
-    0,
-    Math.min(firstPage.body.albums.total - 1, poolLimit)
-  )
-
-  if (albumOffsetToFetch === 0) {
-    return firstPage.body.albums.items[0]
-  }
-
-  return client
-    .search(searchTerm, ['album'], {
-      limit: 1,
-      offset: albumOffsetToFetch,
-    })
-    .then((resp) => {
-      if (!resp.body.albums?.items?.[0]) {
-        console.error(
-          util.inspect(resp, false, 100000, true),
-          albumOffsetToFetch
-        )
-        throw new Error(
-          `could not fetch album for search term from offset (Spotify status code: ${resp.statusCode})`
+      if (!token) {
+        const data = await this.api.clientCredentialsGrant()
+        token = data.body.access_token
+        cache.set(
+          this.clientCredentialsTokenCacheKey,
+          token,
+          data.body.expires_in
         )
       }
 
-      const album = resp.body.albums.items[0]
-
-      if (album.album_type === 'single') {
-        return getRandomAlbumForSearchTerm(searchTerm, poolLimit)
-      }
-
-      return album
-    })
-}
-
-const getRandomAlbumForPublication = async (
-  publicationSlug: string
-): Promise<{
-  review: Awaited<ReturnType<typeof db.getRandomAlbumForPublication>>
-  album: Awaited<ReturnType<typeof getAlbum>>
-}> => {
-  const review = await db.getRandomAlbumForPublication(publicationSlug)
-  const album = await getAlbum(review.album, review.aritst)
-
-  if (!album) {
-    return getRandomAlbumForPublication(publicationSlug)
-  }
-
-  return { review, album }
-}
-
-const getRandomAlbumByGenre = async (
-  genre: string
-): Promise<SpotifyApi.AlbumObjectSimplified | null> => {
-  // First, we must fetch a random artist in this genre
-  const limit = 1
-  const searchTerm = `genre:"${genre}"`
-  const client = await getClient()
-  const firstPageOfArtists = await client.search(searchTerm, ['artist'], {
-    limit,
-  })
-
-  if (!firstPageOfArtists.body.artists?.total) {
-    throw new Error('could not fetch first page of artists')
-  }
-
-  const artistOffsetToFetch = random(
-    0,
-    Math.min(firstPageOfArtists.body.artists.total, 300)
-  )
-
-  let artistID = firstPageOfArtists.body.artists.items[0].id
-
-  if (artistOffsetToFetch > 0) {
-    const artist = await client
-      .search(searchTerm, ['artist'], {
-        limit: 1,
-        offset: artistOffsetToFetch,
-      })
-      .then((page) => page.body.artists?.items?.[0])
-
-    if (!artist) {
-      throw new Error('could not fetch artist from offset')
+      this.api.setAccessToken(token)
     }
 
-    artistID = artist.id
+    return this.api
   }
 
-  // After we fetch a random artist, fetch a random album by them
-  const albums = await client
-    .getArtistAlbums(artistID, {
-      limit: 50,
-      include_groups: 'album',
+  async getRandomAlbumForSearchTerm(searchTerm: string, poolLimit = 1000) {
+    const client = await this.getClient()
+
+    const firstPage = await client.search(searchTerm, ['album'], {
+      limit: 1,
     })
-    .then((page) =>
-      page.body.items.filter((album) => album.album_type !== 'single')
+
+    if (!firstPage.body.albums?.total) {
+      throw new Error('could not fetch first page of albums search term')
+    }
+
+    const albumOffsetToFetch = random(
+      0,
+      Math.min(firstPage.body.albums.total - 1, poolLimit)
     )
 
-  if (!albums.length) {
-    return getRandomAlbumByGenre(genre)
-  }
+    if (albumOffsetToFetch === 0) {
+      return firstPage.body.albums.items[0]
+    }
 
-  return sample(albums) ?? null
-}
-
-const getRandomAlbumForRelatedArtist = async (artistName: string) => {
-  const client = await getClient()
-  // First, we have to fetch the artist to get it's ID
-  const artist = await client
-    .search(`artist:"${artistName}"`, ['artist'], {
+    const resp = await client.search(searchTerm, ['album'], {
       limit: 1,
+      offset: albumOffsetToFetch,
+      market: this.country,
     })
-    .then((resp) => resp.body.artists?.items?.[0])
 
-  if (!artist) {
-    throw new Error('could not find artist with that name')
+    if (!resp.body.albums?.items?.[0]) {
+      console.error(util.inspect(resp, false, 100000, true), albumOffsetToFetch)
+      throw new Error(
+        `could not fetch album for search term from offset (Spotify status code: ${resp.statusCode})`
+      )
+    }
+
+    const album = resp.body.albums.items[0]
+
+    // if (album.album_type === 'single') {
+    //   return this.getRandomAlbumForSearchTerm(searchTerm, poolLimit)
+    // }
+
+    return album
   }
 
-  // Next, we need to fetch the related artists
-  const relatedArtists = await client.getArtistRelatedArtists(artist.id)
+  async getRandomAlbumForArtist(artistName: string) {
+    const client = await this.getClient()
+    const artist = await client
+      .search(`artist:"${artistName}"`, ['artist'], {
+        limit: 1,
+      })
+      .then((resp) => resp.body.artists?.items?.[0])
 
-  if (relatedArtists.statusCode !== 200) {
-    throw new Error('could not fetch related artists')
+    if (!artist) {
+      throw new Error('not found: could not find artist with that name')
+    }
+
+    const firstPage = await client.getArtistAlbums(artist.id, {
+      limit: 1,
+      include_groups: 'album',
+    })
+    const offset = random(0, firstPage.body.total - 1)
+
+    if (offset === 0) {
+      return firstPage.body.items[0]
+    }
+
+    return client
+      .getArtistAlbums(artist.id, {
+        limit: 1,
+        offset,
+        include_groups: 'album',
+        country: this.country,
+      })
+      .then((resp) => resp.body.items[0])
   }
 
-  // Find a random related artist (or the artist that was provided in the
-  // original search term)
-  const targetArtist = sample([...relatedArtists.body.artists, artist])
+  async getRandomAlbumByGenre(
+    genre: string
+  ): Promise<SpotifyApi.AlbumObjectSimplified | null> {
+    // First, we must fetch a random artist in this genre
+    const limit = 1
+    const searchTerm = `genre:"${genre}"`
+    const client = await this.getClient()
+    const firstPageOfArtists = await client.search(searchTerm, ['artist'], {
+      limit,
+      market: this.country,
+    })
 
-  if (!targetArtist) {
-    throw new Error('could not sample to find target artist')
+    if (!firstPageOfArtists.body.artists?.total) {
+      throw new Error('could not fetch first page of artists')
+    }
+
+    const artistOffsetToFetch = random(
+      0,
+      Math.min(firstPageOfArtists.body.artists.total - 1, 300)
+    )
+
+    let artistID = firstPageOfArtists.body.artists.items[0].id
+
+    if (artistOffsetToFetch > 0) {
+      const artist = await client
+        .search(searchTerm, ['artist'], {
+          limit: 1,
+          offset: artistOffsetToFetch,
+          market: this.country,
+        })
+        .then((page) => page.body.artists?.items?.[0])
+
+      if (!artist) {
+        throw new Error('could not fetch artist from offset')
+      }
+
+      artistID = artist.id
+    }
+
+    // After we fetch a random artist, fetch a random album by them
+    const albums = await client
+      .getArtistAlbums(artistID, {
+        limit: 50,
+        include_groups: 'album',
+      })
+      .then((page) =>
+        page.body.items.filter((album) => album.album_type !== 'single')
+      )
+
+    if (!albums.length) {
+      return this.getRandomAlbumByGenre(genre)
+    }
+
+    return sample(albums) ?? null
   }
 
-  // Finally, return a random album from the targetArtist
-  return getRandomAlbumForSearchTerm(`artist:"${targetArtist.name}"`)
-}
+  async getRandomAlbumForRelatedArtist(artistName: string) {
+    const client = await this.getClient()
+    // First, we have to fetch the artist to get it's ID
+    const artist = await client
+      .search(`artist:"${artistName}"`, ['artist'], {
+        limit: 1,
+        market: this.country,
+      })
+      .then((resp) => resp.body.artists?.items?.[0])
 
-const getAlbum = async (album: string, artist: string) =>
-  (await getClient())
-    .search(`album:"${album}" artist:"${artist}"`, ['album'], {
+    if (!artist) {
+      throw new Error('could not find artist with that name')
+    }
+
+    // Next, we need to fetch the related artists
+    const relatedArtists = await client.getArtistRelatedArtists(artist.id)
+
+    if (relatedArtists.statusCode !== 200) {
+      throw new Error('could not fetch related artists')
+    }
+
+    // Find a random related artist (or the artist that was provided in the
+    // original search term)
+    const targetArtist = sample([...relatedArtists.body.artists, artist])
+
+    if (!targetArtist) {
+      throw new Error('could not sample to find target artist')
+    }
+
+    // Finally, return a random album from the targetArtist
+    return this.getRandomAlbumForSearchTerm(`artist:"${targetArtist.name}"`)
+  }
+
+  async getRandomAlbumForPublication(publicationSlug: string): Promise<{
+    review: Awaited<ReturnType<typeof db.getRandomAlbumForPublication>>
+    album: Awaited<ReturnType<typeof getAlbum>>
+  }> {
+    const review = await db.getRandomAlbumForPublication(publicationSlug)
+    const album = await this.getAlbum(review.album, review.aritst)
+
+    if (!album) {
+      return this.getRandomAlbumForPublication(publicationSlug)
+    }
+
+    return { review, album }
+  }
+
+  async getRandomAlbumForLabel(label: string) {
+    return this.getRandomAlbumForSearchTerm(`label:"${label}"`, 500)
+  }
+
+  async getAlbum(album: string, artist: string) {
+    const client = await this.getClient()
+    const resp = await client.search(
+      `album:"${album}" artist:"${artist}"`,
+      ['album'],
+      {
+        limit: 50,
+        market: this.country,
+      }
+    )
+    const albums = resp.body?.albums?.items ?? []
+
+    switch (albums.length) {
+      case 0:
+        throw new Error('could not locate album by searching Spotify')
+      case 1:
+        return albums[0]
+      default:
+        return albums.filter((album) => album.album_type !== 'single')[0]
+    }
+  }
+
+  async getRandomAlbumFromUserLibrary() {
+    if (!this.userAccessToken) {
+      throw new Error('user is not logged in')
+    }
+
+    const client = await this.getClient()
+    const firstPage = await client.getMySavedAlbums({
+      limit: 1,
+      market: this.country,
+    })
+
+    const targetOffset = random(0, firstPage.body.total)
+
+    if (targetOffset === 0) {
+      return firstPage.body.items[0].album
+    }
+
+    return client
+      .getMySavedAlbums({
+        offset: targetOffset,
+        limit: 1,
+        market: this.country,
+      })
+      .then((resp) => resp.body.items[0].album)
+  }
+
+  async getRandomNewRelease() {
+    const client = await this.getClient()
+    const resp = await client.getNewReleases({
+      country: this.country,
+      limit: 50,
+      offset: random(0, 49),
+    })
+
+    return resp.body.albums.items[0]
+  }
+
+  async getRandomFeaturedPlaylist() {
+    const client = await this.getClient()
+    let resp = await client.getFeaturedPlaylists({
+      country: this.country,
+      limit: 1,
+      offset: random(0, 49),
+    })
+
+    if (resp.body.playlists.items.length === 0) {
+      resp = await client.getFeaturedPlaylists({
+        country: this.country,
+        limit: 1,
+        offset: random(0, resp.body.playlists.total - 1),
+      })
+    }
+
+    return resp.body.playlists.items[0]
+  }
+
+  async getCategories() {
+    const cacheKey = `spotify-categories-${this.country}`
+    let categories = cache.get<SpotifyApi.CategoryObject[]>(cacheKey)
+
+    if (categories) {
+      return categories
+    }
+
+    const client = await this.getClient()
+    const resp = await client.getCategories({
+      country: this.country,
       limit: 50,
     })
-    .then((resp) => resp.body.albums?.items ?? [])
-    .then((albums) => albums.filter((album) => album.album_type !== 'single'))
-    .then((albums) => albums?.[0])
 
-const getRandomAlbumFromUserLibrary = async (accessToken: string) => {
-  const client = getUserClient(accessToken)
-  const firstPage = await client.getMySavedAlbums({
-    limit: 1,
-  })
+    categories = resp.body.categories.items
+    cache.set(cacheKey, categories)
 
-  const targetOffset = random(0, firstPage.body.total)
-
-  if (targetOffset === 0) {
-    return firstPage.body.items[0].album
-  }
-
-  return client
-    .getMySavedAlbums({
-      offset: targetOffset,
-      limit: 1,
-    })
-    .then((resp) => resp.body.items[0].album)
-}
-
-const getRandomNewRelease = async (country: string = 'US') => {
-  const client = await getClient()
-  const resp = await client.getNewReleases({
-    country,
-    limit: 50,
-    offset: random(0, 50),
-  })
-
-  return resp.body.albums.items[0]
-}
-
-const getRandomFeaturedPlaylist = async (country = 'US') => {
-  const client = await getClient()
-  let resp = await client.getFeaturedPlaylists({
-    country,
-    limit: 1,
-    offset: random(0, 50),
-  })
-
-  if (resp.body.playlists.items.length === 0) {
-    resp = await client.getFeaturedPlaylists({
-      country,
-      limit: 1,
-      offset: random(0, resp.body.playlists.total - 1),
-    })
-  }
-
-  return resp.body.playlists.items[0]
-}
-
-const getCategories = async (country = 'US') => {
-  const cacheKey = `spotify-categories-${country}`
-  let categories = cache.get<SpotifyApi.CategoryObject[]>(cacheKey)
-
-  if (categories) {
     return categories
   }
 
-  const client = await getClient()
-  const resp = await client.getCategories({
-    country,
-    limit: 50,
-  })
-
-  categories = resp.body.categories.items
-  cache.set(cacheKey, categories)
-
-  return categories
-}
-
-const getRandomPlaylistForCategory = async (
-  categoryID: string,
-  country = 'US'
-) => {
-  const cacheKey = `spotify-category-${categoryID}-${country}`
-  const playlistIdx = random(0, 50)
-  let playlists = cache.get<SpotifyApi.PlaylistObjectSimplified[]>(cacheKey)
-
-  if (playlists) {
-    return playlists[playlistIdx]
+  async getCategory(categoryID: string) {
+    const categories = await this.getCategories()
+    return categories.find((category) => category.id === categoryID)
   }
 
-  const client = await getClient()
-  const resp = await client.getPlaylistsForCategory(categoryID, {
-    country,
-    limit: 50,
-  })
+  async getRandomPlaylistForCategory(categoryID: string) {
+    const client = await this.getClient()
+    const firstPage = await client.getPlaylistsForCategory(categoryID, {
+      country: this.country,
+      limit: 1,
+    })
+    const playlistIdx = random(0, firstPage.body.playlists.total - 1)
 
-  playlists = resp.body.playlists.items
-  cache.set(cacheKey, playlists)
+    if (playlistIdx === 0) {
+      return firstPage.body.playlists.items[0]
+    }
 
-  return playlists[playlistIdx]
+    const playlistResp = await client.getPlaylistsForCategory(categoryID, {
+      country: this.country,
+      limit: 1,
+      offset: playlistIdx,
+    })
+
+    return playlistResp.body.playlists.items[0]
+  }
+
+  async getRandomAlbumForGroupSlug(groupSlug: string) {
+    const artist = await db.getRandomArtistFromGroupSlug(groupSlug)
+
+    if (!artist) {
+      throw new Error(`Could not find artist under group slug '${groupSlug}'`)
+    }
+
+    return this.getRandomAlbumForSearchTerm(`artist:"${artist.name}"`)
+  }
+
+  async getRandomAlbumForLabelSlug(labelSlug: string) {
+    const label = await db.getLabelBySlug(labelSlug)
+
+    if (!label) {
+      throw new Error(`Could not find label for slug '${labelSlug}'`)
+    }
+
+    return this.getRandomAlbumForLabel(label.name)
+  }
 }
 
 const cookieFactory = createCookie('spotify', {
@@ -353,21 +391,6 @@ const cookieFactory = createCookie('spotify', {
 
 const api = {
   cookieFactory,
-  getAlbum,
-  getCategories,
-  getRandomAlbumByGenre,
-  getRandomAlbumForArtist,
-  getRandomAlbumForGroupSlug,
-  getRandomAlbumForLabel,
-  getRandomAlbumForLabelSlug,
-  getRandomAlbumForPublication,
-  getRandomAlbumForRelatedArtist,
-  getRandomAlbumForSearchTerm,
-  getRandomAlbumFromUserLibrary,
-  getRandomFeaturedPlaylist,
-  getRandomNewRelease,
-  getRandomPlaylistForCategory,
-  getUserClient,
 }
 
 export default api

--- a/app/routes/genre/index.tsx
+++ b/app/routes/genre/index.tsx
@@ -1,24 +1,23 @@
 import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
-import clsx from 'clsx'
 
-import db from '~/lib/db'
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import Album from '~/components/Album'
 import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
-import { Layout, Heading, ButtonLink, Container } from '~/components/Base'
-import GenreSearchForm from '~/components/Forms/GenreSearch'
-import ButtonLinkGroup from '~/components/Base/ButtonLinkGroup'
+import { Layout } from '~/components/Base'
 
 export async function loader({ request }: LoaderArgs) {
   const url = new URL(request.url)
   const q = url.searchParams.get('q')
 
   if (!q) {
-    return json({
-      topGenres: await db.getTopGenres(300),
-    })
+    throw json(
+      { error: 'q query param must be provided to search via genre' },
+      400
+    )
   }
+
+  const spotify = await spotifyLib.initializeFromRequest(request)
 
   return json({
     album: await spotify.getRandomAlbumByGenre(q),
@@ -31,33 +30,15 @@ export const ErrorBoundary = AlbumErrorBoundary
 export default function GenreSearch() {
   const data = useLoaderData<typeof loader>()
 
-  if ('album' in data) {
-    const { album, genre } = data
+  const { album, genre } = data
 
-    if (!album?.external_urls?.spotify) {
-      return null
-    }
-
-    return (
-      <Layout headerBreadcrumbs={['Genre', genre]}>
-        <Album album={album} />
-      </Layout>
-    )
+  if (!album?.external_urls?.spotify) {
+    return null
   }
 
   return (
-    <Layout>
-      <Container>
-        <Heading level="h2">Search by Genre</Heading>
-        <GenreSearchForm defaultGenres={data.topGenres} />
-        <ButtonLinkGroup
-          items={data.topGenres}
-          toFunction={(genre) => `/genre?q=${genre}`}
-          keyFunction={(genre) => genre}
-          childFunction={(genre) => genre}
-          wrapperClassName={clsx('mt-4')}
-        />
-      </Container>
+    <Layout headerBreadcrumbs={['Genre', genre]}>
+      <Album album={album} />
     </Layout>
   )
 }

--- a/app/routes/genres.tsx
+++ b/app/routes/genres.tsx
@@ -1,0 +1,37 @@
+import { json } from '@remix-run/node'
+import { useLoaderData } from '@remix-run/react'
+import clsx from 'clsx'
+
+import db from '~/lib/db'
+import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
+import { Layout, Heading, Container } from '~/components/Base'
+import GenreSearchForm from '~/components/Forms/GenreSearch'
+import ButtonLinkGroup from '~/components/Base/ButtonLinkGroup'
+
+export async function loader() {
+  return json({
+    topGenres: await db.getTopGenres(300),
+  })
+}
+
+export const ErrorBoundary = AlbumErrorBoundary
+
+export default function Genres() {
+  const data = useLoaderData<typeof loader>()
+
+  return (
+    <Layout>
+      <Container>
+        <Heading level="h2">Search by Genre</Heading>
+        <GenreSearchForm defaultGenres={data.topGenres} />
+        <ButtonLinkGroup
+          items={data.topGenres}
+          toFunction={(genre) => `/genre?q=${genre}`}
+          keyFunction={(genre) => genre}
+          childFunction={(genre) => genre}
+          wrapperClassName={clsx('mt-4')}
+        />
+      </Container>
+    </Layout>
+  )
+}

--- a/app/routes/group/$slug.tsx
+++ b/app/routes/group/$slug.tsx
@@ -1,15 +1,17 @@
 import { useLoaderData } from '@remix-run/react'
 import { json, LoaderArgs } from '@remix-run/node'
 
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import Album from '~/components/Album'
 import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
 import { Layout } from '~/components/Base'
 
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params, request }: LoaderArgs) {
   if (!params.slug) {
     throw new Error('slug must be provided to this route')
   }
+
+  const spotify = await spotifyLib.initializeFromRequest(request)
 
   return json({
     album: await spotify.getRandomAlbumForGroupSlug(params.slug),

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -73,7 +73,7 @@ export default function Index() {
           <RelatedArtistSearchForm />
         </HomeSection>
         <HomeSection
-          title={<Link to="/genre">Genre</Link>}
+          title={<Link to="/genres">Genre</Link>}
           subtitle="Have a genre in mind? Search for it and we'll find you something."
           className="genre"
         >

--- a/app/routes/label/$slug.tsx
+++ b/app/routes/label/$slug.tsx
@@ -1,17 +1,19 @@
 import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import Album from '~/components/Album'
 import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
 import { Layout } from '~/components/Base'
 
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params, request }: LoaderArgs) {
   const label = params.slug
 
   if (!label) {
     throw new Error('slug must be provided in URL')
   }
+
+  const spotify = await spotifyLib.initializeFromRequest(request)
 
   return json({
     album: await spotify.getRandomAlbumForLabelSlug(label),

--- a/app/routes/label/index.tsx
+++ b/app/routes/label/index.tsx
@@ -1,23 +1,20 @@
 import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
-import clsx from 'clsx'
-
-import db from '~/lib/db'
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import Album from '~/components/Album'
 import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
-import { Layout, Heading, Container } from '~/components/Base'
-import ButtonLinkGroup from '~/components/Base/ButtonLinkGroup'
-import LabelSearchForm from '~/components/Forms/LabelSearch'
+import { Layout } from '~/components/Base'
 
 export async function loader({ request }: LoaderArgs) {
+  const spotify = await spotifyLib.initializeFromRequest(request)
   const url = new URL(request.url)
   const q = url.searchParams.get('q')
 
   if (!q) {
-    return json({
-      labels: await db.getLabels(),
-    })
+    throw json(
+      { error: 'q search paramter must be provided to search labels' },
+      400
+    )
   }
 
   return json({
@@ -31,47 +28,15 @@ export const ErrorBoundary = AlbumErrorBoundary
 export default function LabelSearch() {
   const data = useLoaderData<typeof loader>()
 
-  if ('album' in data) {
-    const { album } = data
+  const { album } = data
 
-    if (!album) {
-      return null
-    }
-
-    return (
-      <Layout headerBreadcrumbs={['Labels', data.label]}>
-        <Album album={album} />
-      </Layout>
-    )
+  if (!album) {
+    return null
   }
 
   return (
-    <Layout>
-      <Container>
-        <Heading level="h2">Search by Label</Heading>
-        <LabelSearchForm />
-        {Object.entries(data.labels).map(([category, labels]) => (
-          <section key={category}>
-            <Heading level="h4">{category}</Heading>
-            <ButtonLinkGroup
-              items={labels}
-              toFunction={(label) => `/label/${label.slug}`}
-              keyFunction={(label) => label.slug}
-              childFunction={(label) => label?.displayName ?? label.name}
-            />
-          </section>
-        ))}
-        <a
-          href="https://genius.com/Gza-labels-lyrics"
-          target="_blank"
-          className={clsx('block', 'w-3/4', 'mx-auto', 'mt-2')}
-        >
-          <img
-            src="/img/rza-labels.png"
-            alt={`Genius lyric cover with the GZA, RZA & Bill Murray saying "You gotta read the label / If you don't read the Label, you might get poisoned" from the GZA song "Labels"`}
-          />
-        </a>
-      </Container>
+    <Layout headerBreadcrumbs={['Labels', data.label]}>
+      <Album album={album} />
     </Layout>
   )
 }

--- a/app/routes/labels.tsx
+++ b/app/routes/labels.tsx
@@ -1,0 +1,51 @@
+import { json } from '@remix-run/node'
+import { useLoaderData } from '@remix-run/react'
+import clsx from 'clsx'
+
+import db from '~/lib/db'
+import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
+import { Layout, Heading, Container } from '~/components/Base'
+import ButtonLinkGroup from '~/components/Base/ButtonLinkGroup'
+import LabelSearchForm from '~/components/Forms/LabelSearch'
+
+export async function loader() {
+  return json({
+    labels: await db.getLabels(),
+  })
+}
+
+export const ErrorBoundary = AlbumErrorBoundary
+
+export default function LabelSearch() {
+  const data = useLoaderData<typeof loader>()
+
+  return (
+    <Layout>
+      <Container>
+        <Heading level="h2">Search by Label</Heading>
+        <LabelSearchForm />
+        {Object.entries(data.labels).map(([category, labels]) => (
+          <section key={category}>
+            <Heading level="h4">{category}</Heading>
+            <ButtonLinkGroup
+              items={labels}
+              toFunction={(label) => `/label/${label.slug}`}
+              keyFunction={(label) => label.slug}
+              childFunction={(label) => label?.displayName ?? label.name}
+            />
+          </section>
+        ))}
+        <a
+          href="https://genius.com/Gza-labels-lyrics"
+          target="_blank"
+          className={clsx('block', 'w-3/4', 'mx-auto', 'mt-2')}
+        >
+          <img
+            src="/img/rza-labels.png"
+            alt={`Genius lyric cover with the GZA, RZA & Bill Murray saying "You gotta read the label / If you don't read the Label, you might get poisoned" from the GZA song "Labels"`}
+          />
+        </a>
+      </Container>
+    </Layout>
+  )
+}

--- a/app/routes/labs.tsx
+++ b/app/routes/labs.tsx
@@ -31,7 +31,7 @@ export default function LibraryPage() {
       <Container>
         <Heading level="h2">Labs 🧪</Heading>
         <HomeSection
-          title={<Link to="/label">Labels</Link>}
+          title={<Link to="/labels">Labels</Link>}
           subtitle="You know labels? Search and we'll see what we have. Otherwise, the link above has some ones to check out."
           className="labels"
         >

--- a/app/routes/publication/$slug.tsx
+++ b/app/routes/publication/$slug.tsx
@@ -2,7 +2,7 @@ import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
 import db from '~/lib/db'
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import { Layout, A } from '~/components/Base'
 import Album from '~/components/Album'
 import BandcampAlbum from '~/components/Album/Bandcamp'
@@ -14,7 +14,7 @@ const searchParams = new URLSearchParams({
   utm_term: 'publication',
 })
 
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params, request }: LoaderArgs) {
   const slug = params.slug
 
   if (!slug) {
@@ -29,6 +29,7 @@ export async function loader({ params }: LoaderArgs) {
     })
   }
 
+  const spotify = await spotifyLib.initializeFromRequest(request)
   const { album, review } = await spotify.getRandomAlbumForPublication(slug)
 
   return json({
@@ -43,10 +44,6 @@ export const ErrorBoundary = AlbumErrorBoundary
 
 export default function PublicationBySlug() {
   const data = useLoaderData<typeof loader>()
-
-  if (!data.album) {
-    return null
-  }
 
   if (data.type === 'bandcamp') {
     return (

--- a/app/routes/related-artist/index.tsx
+++ b/app/routes/related-artist/index.tsx
@@ -2,7 +2,7 @@ import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 import promiseHash from 'promise-hash'
 
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import { Layout } from '~/components/Base'
 import Album from '~/components/Album'
 import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
@@ -15,6 +15,7 @@ export async function loader({ request }: LoaderArgs) {
     return json({ error: 'q query param must be provided' }, 400)
   }
 
+  const spotify = await spotifyLib.initializeFromRequest(request)
   let searchMethod = spotify.getRandomAlbumForRelatedArtist
 
   // If the search term is quoted, get random album for just that artist

--- a/app/routes/spotify/album.tsx
+++ b/app/routes/spotify/album.tsx
@@ -2,7 +2,7 @@ import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
 import auth from '~/lib/auth'
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import { Layout } from '~/components/Base'
 import Album from '~/components/Album'
 import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
@@ -17,10 +17,9 @@ export async function loader({ request }: LoaderArgs) {
     )
   }
 
+  const spotify = await spotifyLib.initializeFromRequest(request)
   const data = {
-    album: await spotify.getRandomAlbumFromUserLibrary(
-      cookie.spotify.accessToken
-    ),
+    album: await spotify.getRandomAlbumFromUserLibrary(),
   }
 
   return json(data, {

--- a/app/routes/spotify/categories.tsx
+++ b/app/routes/spotify/categories.tsx
@@ -1,15 +1,17 @@
-import { json, MetaFunction } from '@remix-run/node'
+import { json, MetaFunction, LoaderArgs } from '@remix-run/node'
 import { useLoaderData, Link } from '@remix-run/react'
 import clsx from 'clsx'
 
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import { Layout, Container, Heading } from '~/components/Base'
 
 export const meta: MetaFunction = () => ({
   title: 'Spotify Playlist Categories | Album Mode.party 🎉',
 })
 
-export async function loader() {
+export async function loader({ request }: LoaderArgs) {
+  const spotify = await spotifyLib.initializeFromRequest(request)
+
   return json({
     categories: await spotify.getCategories(),
   })

--- a/app/routes/spotify/category/$id.tsx
+++ b/app/routes/spotify/category/$id.tsx
@@ -1,12 +1,12 @@
 import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import { Layout, Link } from '~/components/Base'
 import Playlist from '~/components/Album/Playlist'
 import PlaylistErrorBoundary from '~/components/Album/ErrorBoundary'
 
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params, request }: LoaderArgs) {
   const categoryID = params.id
 
   if (!categoryID) {
@@ -18,6 +18,7 @@ export async function loader({ params }: LoaderArgs) {
     )
   }
 
+  const spotify = await spotifyLib.initializeFromRequest(request)
   const data = {
     playlist: await spotify.getRandomPlaylistForCategory(categoryID),
     category: await spotify.getCategory(categoryID),

--- a/app/routes/spotify/featured-playlist.tsx
+++ b/app/routes/spotify/featured-playlist.tsx
@@ -1,12 +1,14 @@
-import { json } from '@remix-run/node'
+import { json, LoaderArgs } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import { Layout } from '~/components/Base'
 import Playlist from '~/components/Album/Playlist'
 import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
 
-export async function loader() {
+export async function loader({ request }: LoaderArgs) {
+  const spotify = await spotifyLib.initializeFromRequest(request)
+
   return json({
     playlist: await spotify.getRandomFeaturedPlaylist(),
   })

--- a/app/routes/spotify/new-releases.tsx
+++ b/app/routes/spotify/new-releases.tsx
@@ -1,17 +1,16 @@
 import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
-import spotify from '~/lib/spotify'
+import spotifyLib from '~/lib/spotify'
 import { Layout } from '~/components/Base'
 import Album from '~/components/Album'
 import AlbumErrorBoundary from '~/components/Album/ErrorBoundary'
 
 export async function loader({ request }: LoaderArgs) {
-  const url = new URL(request.url)
-  const country = url.searchParams.get('country') || undefined
+  const spotify = await spotifyLib.initializeFromRequest(request)
 
   return json({
-    album: await spotify.getRandomNewRelease(country),
+    album: await spotify.getRandomNewRelease(),
   })
 }
 


### PR DESCRIPTION
- Refactor Spotify methods into a class. The theory that I had, that ended up proving correct, is that Spotify's category playlist endpoint is more reliable when the user is logged in, which wasn't easily doable with loose functions. Also, with this method, I can open up the user to set their country as an option.
- Reduce complexity of genre and label pages by moving the listing pages into dedicated pages.