### PR TITLE
Publication Audit + Typo Fixes

### DIFF
--- a/app/lib/db.server.ts
+++ b/app/lib/db.server.ts
@@ -4,7 +4,7 @@ import {
   AlbumReviewedByPublication,
   Artist,
   BandcampDailyAlbum,
-  SpotifyGenere,
+  SpotifyGenre,
   Publication,
 } from '@prisma/client'
 import groupBy from 'lodash/groupBy'
@@ -82,7 +82,7 @@ const getRandomArtistFromGroupSlug = async (groupSlug: string) =>
 const getRandomAlbumForPublication = async (publicationSlug: string) =>
   prisma
     .$queryRaw<
-      (Pick<AlbumReviewedByPublication, 'id' | 'aritst' | 'album' | 'slug'> & {
+      (Pick<AlbumReviewedByPublication, 'id' | 'artist' | 'album' | 'slug'> & {
         publicationName: string
         publicationBlurb: string | null
       })[]
@@ -90,7 +90,7 @@ const getRandomAlbumForPublication = async (publicationSlug: string) =>
       Prisma.sql`
         SELECT
           a.id,
-          a.aritst,
+          a.artist,
           a.album,
           a.slug,
           p.name AS publicationName,
@@ -138,7 +138,7 @@ const getRandomBandcampDailyAlbum = async () =>
     .then((res) => res[0])
 
 const searchGenres = async (q: string): Promise<string[]> => {
-  return prisma.spotifyGenere
+  return prisma.spotifyGenre
     .findMany({
       select: {
         name: true,
@@ -158,7 +158,7 @@ const searchGenres = async (q: string): Promise<string[]> => {
 }
 
 const getTopGenres = async (limit = 100): Promise<string[]> =>
-  prisma.spotifyGenere
+  prisma.spotifyGenre
     .findMany({
       select: {
         name: true,
@@ -172,10 +172,10 @@ const getTopGenres = async (limit = 100): Promise<string[]> =>
 
 const getRandomGenre = async (): Promise<string> =>
   prisma
-    .$queryRaw<Pick<SpotifyGenere, 'name'>[]>(
+    .$queryRaw<Pick<SpotifyGenre, 'name'>[]>(
       Prisma.sql`
         SELECT name
-        FROM SpotifyGenere
+        FROM SpotifyGenre
         ORDER BY RANDOM()
         LIMIT 1
       `
@@ -184,14 +184,14 @@ const getRandomGenre = async (): Promise<string> =>
 
 const getRandomTopGenre = async (limit = 50): Promise<string> =>
   prisma
-    .$queryRaw<Pick<SpotifyGenere, 'name'>[]>(
+    .$queryRaw<Pick<SpotifyGenre, 'name'>[]>(
       Prisma.sql`
         SELECT name
-        FROM SpotifyGenere
+        FROM SpotifyGenre
         WHERE (
           id = (
             SELECT id
-            FROM SpotifyGenere
+            FROM SpotifyGenre
             WHERE id < ${limit}
             ORDER BY RANDOM()
             LIMIT 1

--- a/app/lib/db.server.ts
+++ b/app/lib/db.server.ts
@@ -104,6 +104,7 @@ const getRandomAlbumForPublication = async (publicationSlug: string) =>
             publication.slug = ${publicationSlug}
             AND albumReviewedByPublication.publicationID = publication.id
           )
+          WHERE albumReviewedByPublication.resolvable = true
           ORDER BY random()
           LIMIT 1
         )

--- a/app/lib/spotify.server.ts
+++ b/app/lib/spotify.server.ts
@@ -301,7 +301,7 @@ export class Spotify {
     album: SpotifyApi.AlbumObjectSimplified
   }> => {
     const review = await db.getRandomAlbumForPublication(publicationSlug)
-    const album = await this.getAlbum(review.album, review.aritst)
+    const album = await this.getAlbum(review.album, review.artist)
 
     if (!album) {
       return this.getRandomAlbumForPublication(publicationSlug)

--- a/app/routes/publication/$slug.tsx
+++ b/app/routes/publication/$slug.tsx
@@ -102,9 +102,7 @@ export default function PublicationBySlug() {
   let breadcrumbs: SearchBreadcrumbsProps['crumbs'] = ['Publication']
 
   if (data.slug.includes('p4k') && 'review' in data) {
-    const url = new URL(
-      `https://pitchfork.com${data.review.slug}?${searchParams.toString()}`
-    )
+    const url = new URL(`https://pitchfork.com${data.review.slug}`)
 
     footer = (
       <Heading level="h5">

--- a/app/routes/publication/$slug.tsx
+++ b/app/routes/publication/$slug.tsx
@@ -89,7 +89,6 @@ export default function PublicationBySlug() {
                 >
                   Bandcamp Daily review
                 </A>
-                .
               </Heading>
               <WikipediaSummary summary={data.wiki} />
             </>
@@ -113,7 +112,6 @@ export default function PublicationBySlug() {
         <A href={url.toString()} target="_blank">
           Pitchfork Review
         </A>
-        .
       </Heading>
     )
     breadcrumbs.push([
@@ -132,7 +130,6 @@ export default function PublicationBySlug() {
         <A href={data.review.slug} target="_blank">
           Needle Drop review on YouTube
         </A>
-        .
       </Heading>
     )
     breadcrumbs.push([

--- a/app/routes/publication/$slug.tsx
+++ b/app/routes/publication/$slug.tsx
@@ -102,7 +102,8 @@ export default function PublicationBySlug() {
   let breadcrumbs: SearchBreadcrumbsProps['crumbs'] = ['Publication']
 
   if (data.slug.includes('p4k') && 'review' in data) {
-    const url = new URL(`https://pitchfork.com${data.review.slug}`)
+    const url = new URL(data.review.slug)
+    url.searchParams.set('utm_campaign', 'publication')
 
     footer = (
       <Heading level="h5">
@@ -122,10 +123,13 @@ export default function PublicationBySlug() {
       </A>,
     ])
   } else if (data.slug === 'needle-drop' && 'review' in data) {
+    const url = new URL(data.review.slug)
+    url.searchParams.set('utm_campaign', 'publication')
+
     footer = (
       <Heading level="h5">
         Watch the{' '}
-        <A href={data.review.slug} target="_blank">
+        <A href={url.toString()} target="_blank">
           Needle Drop review on YouTube
         </A>
       </Heading>

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-spotify-embed": "^0.2.3",
         "react-use": "^17.3.2",
         "spotify-web-api-node": "^5.0.2",
+        "string-strip-html": "^11.1.0",
         "wikipedia": "^1.1.9"
       },
       "devDependencies": {
@@ -9271,6 +9272,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
+    },
     "node_modules/htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -10570,6 +10576,11 @@
       "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=",
       "dev": true
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -10599,8 +10610,7 @@
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "node_modules/lodash.map": {
       "version": "4.6.0",
@@ -10631,6 +10641,16 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+    },
+    "node_modules/lodash.trim": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
+      "integrity": "sha512-nJAlRl/K+eiOehWKDzoBVrSMhK0K3A3YQsUNXHQa5yIrKBAhsZgSu3KoAFoFT+mEgiyBHddZ0pRk1ITpIp90Wg=="
+    },
+    "node_modules/lodash.without": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha512-M3MefBwfDhgKgINVuBJCO1YR3+gf6s9HNJsIiZ/Ru77Ws6uTb9eBuvrkpzO+9iLoAaRodGuq7tyrPCx+74QYGQ=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -13208,6 +13228,50 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ranges-apply": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/ranges-apply/-/ranges-apply-6.1.5.tgz",
+      "integrity": "sha512-xLwTwuUvXs9i+li7y5s/r71IthyMJFvTGsZpvRrjSGJ1NH4zVjR3roKuZmHLqgiCMA32gn1nmBOyMhn6OELtSg==",
+      "dependencies": {
+        "ranges-merge": "^8.1.4",
+        "tiny-invariant": "^1.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/ranges-merge": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/ranges-merge/-/ranges-merge-8.1.4.tgz",
+      "integrity": "sha512-sgH1cJpV5HRLwmh1Wr41kJQIMQnNKYnXFoWcU70lFYWMULeVvv9wX1MAojt4AgStopD436vMOveusPzXL67wnA==",
+      "dependencies": {
+        "ranges-push": "^6.1.4",
+        "ranges-sort": "^5.0.14"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/ranges-push": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/ranges-push/-/ranges-push-6.1.4.tgz",
+      "integrity": "sha512-NTYev7q5UtQFuEvSg2ZzaY9OSvgw3Iy9mzadwsyYgL8TgeY79RTBcC5M1HbGBzB+hiMbMoQ7Ns45MH+MyBz0lw==",
+      "dependencies": {
+        "string-collapse-leading-whitespace": "^6.0.15",
+        "string-trim-spaces-only": "^4.0.14"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/ranges-sort": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/ranges-sort/-/ranges-sort-5.0.14.tgz",
+      "integrity": "sha512-2IuyAOxMECXB6J18wPdE8uYXo4+Ut6KesIND8a6o3hr9xvxfyjDB++WwDVRuZXd6baIvJXpOujiZ3A9S5OQ2lQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/raw-body": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
@@ -15137,6 +15201,51 @@
         }
       ]
     },
+    "node_modules/string-collapse-leading-whitespace": {
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/string-collapse-leading-whitespace/-/string-collapse-leading-whitespace-6.0.15.tgz",
+      "integrity": "sha512-FL7LwQ9Hrk7BqCXX0Sr13jiJno+/qGQD5daEF5f6fdgY2WV/RGRqn1tEn2xMb0UITFD1cXFn/o9PVBfB3kBsVw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/string-left-right": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/string-left-right/-/string-left-right-5.0.14.tgz",
+      "integrity": "sha512-tS3pYFG6ooSwtmBmif89HY02kQ+3yQS5+olZqLtb/QO2HaZ4mtxFj7HuliidnzkQe13Ma4+HeddMWVQgOuI9bw==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isplainobject": "^4.0.6"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/string-strip-html": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-11.1.0.tgz",
+      "integrity": "sha512-6mcCxx0Sjru74vaUOJtwrnJs5tHuB8MIf5rzupfAWDNce36pCk2MZLgXim+ECIoQC0hJgo5U9U60SPesNnabJA==",
+      "dependencies": {
+        "html-entities": "^2.3.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.trim": "^4.5.1",
+        "lodash.without": "^4.4.0",
+        "ranges-apply": "^6.1.5",
+        "ranges-push": "^6.1.4",
+        "string-left-right": "^5.0.14"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/string-trim-spaces-only": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/string-trim-spaces-only/-/string-trim-spaces-only-4.0.14.tgz",
+      "integrity": "sha512-hLin5pKm5i8UBMO1HHm9YCtH6Q3hpLJTGIeB8dMotNKD6GnQwywqFnprzmcDhXZFmz5I15A7rG2dByFqNmTVcA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -15539,6 +15648,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "node_modules/tinyreq": {
       "version": "3.4.2",
@@ -23508,6 +23622,11 @@
         "whatwg-encoding": "^2.0.0"
       }
     },
+    "html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
+    },
     "htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -24493,6 +24612,11 @@
       "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -24522,8 +24646,7 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -24554,6 +24677,16 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+    },
+    "lodash.trim": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
+      "integrity": "sha512-nJAlRl/K+eiOehWKDzoBVrSMhK0K3A3YQsUNXHQa5yIrKBAhsZgSu3KoAFoFT+mEgiyBHddZ0pRk1ITpIp90Wg=="
+    },
+    "lodash.without": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha512-M3MefBwfDhgKgINVuBJCO1YR3+gf6s9HNJsIiZ/Ru77Ws6uTb9eBuvrkpzO+9iLoAaRodGuq7tyrPCx+74QYGQ=="
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -26337,6 +26470,38 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
     },
+    "ranges-apply": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/ranges-apply/-/ranges-apply-6.1.5.tgz",
+      "integrity": "sha512-xLwTwuUvXs9i+li7y5s/r71IthyMJFvTGsZpvRrjSGJ1NH4zVjR3roKuZmHLqgiCMA32gn1nmBOyMhn6OELtSg==",
+      "requires": {
+        "ranges-merge": "^8.1.4",
+        "tiny-invariant": "^1.2.0"
+      }
+    },
+    "ranges-merge": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/ranges-merge/-/ranges-merge-8.1.4.tgz",
+      "integrity": "sha512-sgH1cJpV5HRLwmh1Wr41kJQIMQnNKYnXFoWcU70lFYWMULeVvv9wX1MAojt4AgStopD436vMOveusPzXL67wnA==",
+      "requires": {
+        "ranges-push": "^6.1.4",
+        "ranges-sort": "^5.0.14"
+      }
+    },
+    "ranges-push": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/ranges-push/-/ranges-push-6.1.4.tgz",
+      "integrity": "sha512-NTYev7q5UtQFuEvSg2ZzaY9OSvgw3Iy9mzadwsyYgL8TgeY79RTBcC5M1HbGBzB+hiMbMoQ7Ns45MH+MyBz0lw==",
+      "requires": {
+        "string-collapse-leading-whitespace": "^6.0.15",
+        "string-trim-spaces-only": "^4.0.14"
+      }
+    },
+    "ranges-sort": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/ranges-sort/-/ranges-sort-5.0.14.tgz",
+      "integrity": "sha512-2IuyAOxMECXB6J18wPdE8uYXo4+Ut6KesIND8a6o3hr9xvxfyjDB++WwDVRuZXd6baIvJXpOujiZ3A9S5OQ2lQ=="
+    },
     "raw-body": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
@@ -27888,6 +28053,39 @@
         }
       }
     },
+    "string-collapse-leading-whitespace": {
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/string-collapse-leading-whitespace/-/string-collapse-leading-whitespace-6.0.15.tgz",
+      "integrity": "sha512-FL7LwQ9Hrk7BqCXX0Sr13jiJno+/qGQD5daEF5f6fdgY2WV/RGRqn1tEn2xMb0UITFD1cXFn/o9PVBfB3kBsVw=="
+    },
+    "string-left-right": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/string-left-right/-/string-left-right-5.0.14.tgz",
+      "integrity": "sha512-tS3pYFG6ooSwtmBmif89HY02kQ+3yQS5+olZqLtb/QO2HaZ4mtxFj7HuliidnzkQe13Ma4+HeddMWVQgOuI9bw==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isplainobject": "^4.0.6"
+      }
+    },
+    "string-strip-html": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-11.1.0.tgz",
+      "integrity": "sha512-6mcCxx0Sjru74vaUOJtwrnJs5tHuB8MIf5rzupfAWDNce36pCk2MZLgXim+ECIoQC0hJgo5U9U60SPesNnabJA==",
+      "requires": {
+        "html-entities": "^2.3.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.trim": "^4.5.1",
+        "lodash.without": "^4.4.0",
+        "ranges-apply": "^6.1.5",
+        "ranges-push": "^6.1.4",
+        "string-left-right": "^5.0.14"
+      }
+    },
+    "string-trim-spaces-only": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/string-trim-spaces-only/-/string-trim-spaces-only-4.0.14.tgz",
+      "integrity": "sha512-hLin5pKm5i8UBMO1HHm9YCtH6Q3hpLJTGIeB8dMotNKD6GnQwywqFnprzmcDhXZFmz5I15A7rG2dByFqNmTVcA=="
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -28218,6 +28416,11 @@
           }
         }
       }
+    },
+    "tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "tinyreq": {
       "version": "3.4.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-spotify-embed": "^0.2.3",
     "react-use": "^17.3.2",
     "spotify-web-api-node": "^5.0.2",
+    "string-strip-html": "^11.1.0",
     "wikipedia": "^1.1.9"
   },
   "devDependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,7 +36,7 @@ model AlbumReviewedByPublication {
   updatedAt DateTime @updatedAt
   publication Publication @relation(fields: [publicationID], references: [id])
   publicationID Int
-  aritst String
+  artist String
   album String
   slug String @unique
   resolvable Boolean @default(true)
@@ -72,7 +72,7 @@ model Artist {
   name String
 }
 
-model SpotifyGenere {
+model SpotifyGenre {
   id Int @id @default(autoincrement())
   name String @unique
   createdAt DateTime @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,7 @@ model AlbumReviewedByPublication {
   aritst String
   album String
   slug String @unique
+  resolvable Boolean @default(true)
 }
 
 model BandcampDailyAlbum {

--- a/prisma/seed-scripts/album-of-the-year.ts
+++ b/prisma/seed-scripts/album-of-the-year.ts
@@ -91,7 +91,7 @@ const seedAlbumOfTheYear = async (options: Options) => {
         data: {
           publicationID: publication.id,
           album: album,
-          aritst: artist,
+          artist: artist,
           slug: `albumoftheyear.org/list/${options.listID}#${kebabCase(
             `${album}-${artist}`
           )}`,

--- a/prisma/seed-scripts/needle-drop.ts
+++ b/prisma/seed-scripts/needle-drop.ts
@@ -110,7 +110,7 @@ const needleDrop = async () => {
         data: {
           publicationID: publication.id,
           album: album,
-          aritst: artist,
+          artist: artist,
           slug: reviewURL,
         },
       })

--- a/prisma/seed-scripts/pazz-and-jop.ts
+++ b/prisma/seed-scripts/pazz-and-jop.ts
@@ -67,7 +67,7 @@ const seedPazzAndJop = async () => {
                 data: {
                   publicationID: 1,
                   album,
-                  aritst: artist,
+                  artist: artist,
                   slug: `/christgau/${path}#${kebabCase(`${artist} ${album}`)}`,
                 },
               })

--- a/prisma/seed-scripts/pitchfork.ts
+++ b/prisma/seed-scripts/pitchfork.ts
@@ -24,7 +24,7 @@ const scrapeP4k = async (slug: PitchforkSlug) => {
   }
 
   const searchParams = new URLSearchParams()
-  searchParams.set('utm_campaign', 'album-mode.party')
+  searchParams.set('utm_source', 'album-mode.party')
   searchParams.set('utm_term', `p4k-${slug}`)
 
   // Since we have bootstrapped all the older albums, limit the update jobs to
@@ -53,7 +53,9 @@ const scrapeP4k = async (slug: PitchforkSlug) => {
           data: {
             publicationID: publication.id,
             album: album.seoTitle || album.title,
-            slug: `${album.url}?${searchParams.toString()}`,
+            slug: `https://pitchfork.com${
+              album.url
+            }?${searchParams.toString()}`,
             artist: album.artists?.[0]?.display_name || '',
           },
         })

--- a/prisma/seed-scripts/pitchfork.ts
+++ b/prisma/seed-scripts/pitchfork.ts
@@ -52,7 +52,7 @@ const scrapeP4k = async (slug: PitchforkSlug) => {
         .create({
           data: {
             publicationID: publication.id,
-            album: album.promoTitle,
+            album: album.seoTitle || album.title,
             slug: `${album.url}?${searchParams.toString()}`,
             artist: album.artists?.[0]?.display_name || '',
           },

--- a/prisma/seed-scripts/pitchfork.ts
+++ b/prisma/seed-scripts/pitchfork.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client'
 import axios from 'axios'
 import yargs from 'yargs'
 import Bottleneck from 'bottleneck'
+import { stripHtml } from 'string-strip-html'
 import { PitchforkSearchResponse, ListEntity } from '~/lib/types/pitchfork'
 
 const prisma = new PrismaClient()
@@ -52,7 +53,7 @@ const scrapeP4k = async (slug: PitchforkSlug) => {
         .create({
           data: {
             publicationID: publication.id,
-            album: album.seoTitle || album.title,
+            album: stripHtml(album.seoTitle || album.title).result,
             slug: `https://pitchfork.com${
               album.url
             }?${searchParams.toString()}`,

--- a/prisma/seed-scripts/pitchfork.ts
+++ b/prisma/seed-scripts/pitchfork.ts
@@ -54,7 +54,7 @@ const scrapeP4k = async (slug: PitchforkSlug) => {
             publicationID: publication.id,
             album: album.promoTitle,
             slug: `${album.url}?${searchParams.toString()}`,
-            aritst: album.artists?.[0]?.display_name || '',
+            artist: album.artists?.[0]?.display_name || '',
           },
         })
         .then(() => inserted++)

--- a/prisma/seed-scripts/spotify-genres.ts
+++ b/prisma/seed-scripts/spotify-genres.ts
@@ -15,7 +15,7 @@ const main = async () => {
 
     await Promise.all(
       genres.map((genre) =>
-        txn.spotifyGenere
+        txn.spotifyGenre
           .create({
             data: {
               name: genre,

--- a/scripts/auditPublicationResolvability.ts
+++ b/scripts/auditPublicationResolvability.ts
@@ -41,7 +41,7 @@ const main = async () => {
   })
 
   await Promise.all(
-    albums.map(({ id, aritst: artist, album }) =>
+    albums.map(({ id, artist, album }) =>
       updateAlbumResolvability(id, artist, album)
     )
   )

--- a/scripts/auditPublicationResolvability.ts
+++ b/scripts/auditPublicationResolvability.ts
@@ -1,0 +1,50 @@
+import Bottleneck from 'bottleneck'
+
+import { prisma } from '~/lib/db.server'
+import { Spotify } from '~/lib/spotify.server'
+
+const spotify = new Spotify()
+const limiter = new Bottleneck({
+  maxConcurrent: 10,
+  minTime: 3 * 1000,
+})
+
+const updateAlbumResolvability = limiter.wrap(
+  async (id: number, artist: string, album: string) => {
+    let resolvable = false
+
+    try {
+      await spotify.getAlbum(album, artist)
+      resolvable = true
+    } catch (e) {
+      console.log(`${album} by ${artist} is not resolvable`)
+    }
+
+    await prisma.albumReviewedByPublication.update({
+      data: {
+        resolvable,
+      },
+      where: {
+        id,
+      },
+    })
+  }
+)
+
+const main = async () => {
+  const albums = await prisma.albumReviewedByPublication.findMany({
+    where: {
+      id: {
+        gt: 1956,
+      },
+    },
+  })
+
+  await Promise.all(
+    albums.map(({ id, aritst: artist, album }) =>
+      updateAlbumResolvability(id, artist, album)
+    )
+  )
+}
+
+main()


### PR DESCRIPTION
- Finally fix some really annoying typos in the database schema by created a new database and manually copying data into it.
- Add script that audits all albums reviewed by publications to ensure that they can be pulled from Spotify. There are a bunch of issues that need to be fixed manually, but I knocked out a bunch for Pazz & Jop.
- Fix some dirty data and simplify some slugs.