### PR TITLE
Display associated genres in publication view

### DIFF
--- a/app/components/Base/index.tsx
+++ b/app/components/Base/index.tsx
@@ -26,7 +26,7 @@ export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
             'text-2xl md:text-3xl': level === 'h3',
             'text-xl md:text-2xl': level === 'h4',
             'uppercase font-bold text-xs': level === 'h5',
-            'text-xs font-bold': level === 'h6',
+            'uppercase text-xs font-bold': level === 'h6',
           },
           !noSpacing && 'my-4',
           className

--- a/app/lib/spotify.server.ts
+++ b/app/lib/spotify.server.ts
@@ -345,6 +345,9 @@ export class Spotify {
       case 1:
         return {
           ...albums[0],
+          // @TODO Maybe one day, we could defer this as an unresolved provmise
+          // using Remix? This doubles the response time of this function and is
+          // somewhat non-critical.
           genres: await this.getGenreForArtist(albums[0].artists[0].id),
         }
       default: {

--- a/app/lib/spotify.server.ts
+++ b/app/lib/spotify.server.ts
@@ -321,6 +321,12 @@ export class Spotify {
     return this.getRandomAlbumForSearchTerm(`label:"${label}"`, 500)
   }
 
+  async getGenreForArtist(artistID: string) {
+    const client = await this.getClient()
+    const resp = await client.getArtist(artistID)
+    return resp.body.genres
+  }
+
   async getAlbum(album: string, artist: string) {
     const client = await this.getClient()
     const resp = await client.search(
@@ -337,9 +343,18 @@ export class Spotify {
       case 0:
         throw new Error('could not locate album by searching Spotify')
       case 1:
-        return albums[0]
-      default:
-        return albums.filter((album) => album.album_type !== 'single')[0]
+        return {
+          ...albums[0],
+          genres: await this.getGenreForArtist(albums[0].artists[0].id),
+        }
+      default: {
+        const album = albums.sort((a) => (a.album_type !== 'single' ? 1 : 0))[0]
+
+        return {
+          ...album,
+          genres: await this.getGenreForArtist(album.artists[0].id),
+        }
+      }
     }
   }
 

--- a/app/routes/publication/$slug.tsx
+++ b/app/routes/publication/$slug.tsx
@@ -1,6 +1,7 @@
 import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 import retry from 'async-retry'
+import clsx from 'clsx'
 
 import db from '~/lib/db.server'
 import spotifyLib from '~/lib/spotify.server'
@@ -14,6 +15,7 @@ import AlbumErrorBoundary, {
 import { SearchBreadcrumbsProps } from '~/components/SearchBreadcrumbs'
 import wikipedia from '~/lib/wikipedia.server'
 import WikipediaSummary from '~/components/WikipediaSummary'
+import ButtonLinkGroup from '~/components/Base/ButtonLinkGroup'
 
 export async function loader({ params, request, context }: LoaderArgs) {
   const headers = new Headers()
@@ -219,6 +221,20 @@ export default function PublicationBySlug() {
           <>
             {footer}
             <WikipediaSummary summary={data.wiki} />
+            {data.album.genres.length > 0 && (
+              <>
+                <Heading level="h6" className={clsx('mb-2')}>
+                  Genres
+                </Heading>
+                <ButtonLinkGroup
+                  items={data.album.genres.slice(0, 3)}
+                  keyFunction={(genre) => genre}
+                  toFunction={(genre) => `/genre?genre=${genre}`}
+                  childFunction={(genre) => genre}
+                  className={clsx('btn-xs')}
+                />
+              </>
+            )}
           </>
         }
       />


### PR DESCRIPTION
This is doubling response times, which is less than ideal. Maybe I could defer it in an upcoming release?