### PR TITLE
Add genre tags to most spotify album views

### DIFF
--- a/app/components/Album/ReviewButtons.tsx
+++ b/app/components/Album/ReviewButtons.tsx
@@ -4,6 +4,7 @@ import useWindowSize from 'react-use/lib/useWindowSize'
 import clsx from 'clsx'
 
 import { ButtonLink, Heading, EmojiText } from '~/components/Base'
+import ButtonLinkGroup from '~/components/Base/ButtonLinkGroup'
 import useRating from '~/hooks/useRating'
 import useCurrentPath from '~/hooks/useCurrentPath'
 import type { LibraryItem } from '~/lib/types/library'
@@ -52,6 +53,21 @@ const ReviewButtons: React.FC<ReviewButtonProps> = ({ item }) => {
   return (
     <>
       <div className={clsx('flex', 'flex-col', 'gap-2', 'w-full')}>
+        {item.type === 'album' && item.genres && item.genres.length > 0 && (
+          <>
+            <Heading level="h5" noSpacing>
+              Genres
+            </Heading>
+            <ButtonLinkGroup
+              items={item.genres.slice(0, 3)}
+              keyFunction={(genre) => genre}
+              toFunction={(genre) => `/genre?genre=${genre}`}
+              childFunction={(genre) => genre}
+              className={clsx('btn-xs')}
+              wrapperClassName={clsx('mb-2')}
+            />
+          </>
+        )}
         <Heading level="h5" noSpacing>
           Rate to get the next recommendation
         </Heading>

--- a/app/config.ts
+++ b/app/config.ts
@@ -4,6 +4,12 @@ const config = {
     public: `public, max-age=${60 * 60 * 24}, s-maxage=${60 * 60 * 24}`,
     private: `private, max-age=${60 * 60 * 12}`,
   },
+  asyncRetryConfig: {
+    retries: 5,
+    factor: 0,
+    minTimeout: 0,
+    randomize: false,
+  },
 }
 
 export default config

--- a/app/lib/types/library.ts
+++ b/app/lib/types/library.ts
@@ -4,11 +4,14 @@ export type SavedItem<T> = T & {
   savedAt: Date
 }
 
-export type SpotifyLibraryItem =
+export type SpotifyLibraryItem = (
   | SpotifyApi.PlaylistObjectFull
   | SpotifyApi.PlaylistObjectSimplified
   | SpotifyApi.AlbumObjectFull
   | SpotifyApi.AlbumObjectSimplified
+) & {
+  genres?: string[]
+}
 
 export type BandcampLibraryItem = BandcampDailyAlbum & { type: 'bandcamp' }
 export type LibraryItem = SpotifyLibraryItem | BandcampLibraryItem

--- a/app/routes/spotify/currently-playing.tsx
+++ b/app/routes/spotify/currently-playing.tsx
@@ -1,5 +1,6 @@
 import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
+import retry from 'async-retry'
 
 import auth from '~/lib/auth.server'
 import spotifyLib from '~/lib/spotify.server'
@@ -11,6 +12,7 @@ import AlbumErrorBoundary, {
 } from '~/components/Album/ErrorBoundary'
 import wikipedia from '~/lib/wikipedia.server'
 import WikipediaSummary from '~/components/WikipediaSummary'
+import config from '~/config'
 
 export async function loader({ request, context }: LoaderArgs) {
   const cookie = await auth.getCookie(request)
@@ -26,10 +28,17 @@ export async function loader({ request, context }: LoaderArgs) {
   const spotify = await serverTiming.track('spotify.init', () =>
     spotifyLib.initializeFromRequest(request)
   )
-  const { album, currentlyPlaying } = await serverTiming.track(
-    'spotify.fetch',
-    () => spotify.getRandomAlbumSimilarToWhatIsCurrentlyPlaying()
-  )
+  const { album, currentlyPlaying } = await retry(async (_, attempt) => {
+    const album = await serverTiming.track('spotify.fetch', () =>
+      spotify.getRandomAlbumSimilarToWhatIsCurrentlyPlaying()
+    )
+    serverTiming.add({
+      label: 'attempts',
+      desc: `${attempt} Attempt(s)`,
+    })
+
+    return album
+  }, config.asyncRetryConfig)
   const wiki = await serverTiming.track('wikipedia', () =>
     wikipedia.getSummaryForAlbum({
       album: album.name,

--- a/app/routes/spotify/new-releases.tsx
+++ b/app/routes/spotify/new-releases.tsx
@@ -1,5 +1,6 @@
 import { LoaderArgs, json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
+import retry from 'async-retry'
 
 import spotifyLib from '~/lib/spotify.server'
 import lastPresented from '~/lib/lastPresented.server'
@@ -10,6 +11,7 @@ import AlbumErrorBoundary, {
 } from '~/components/Album/ErrorBoundary'
 import wikipedia from '~/lib/wikipedia.server'
 import WikipediaSummary from '~/components/WikipediaSummary'
+import config from '~/config'
 
 export async function loader({ request, context }: LoaderArgs) {
   const headers = new Headers()
@@ -17,9 +19,17 @@ export async function loader({ request, context }: LoaderArgs) {
   const spotify = await serverTiming.track('spotify.init', () =>
     spotifyLib.initializeFromRequest(request)
   )
-  const album = await serverTiming.track('spotify.fetch', () =>
-    spotify.getRandomNewRelease()
-  )
+  const album = await retry(async (_, attempt) => {
+    const album = await serverTiming.track('spotify.fetch', () =>
+      spotify.getRandomNewRelease()
+    )
+    serverTiming.add({
+      label: 'attempts',
+      desc: `${attempt} Attempt(s)`,
+    })
+
+    return album
+  }, config.asyncRetryConfig)
   const wiki = await serverTiming.track('wikipedia', () =>
     wikipedia.getSummaryForAlbum({
       album: album.name,


### PR DESCRIPTION
- The genre tags have been _super_ useful for me to browse stuff, so I decided to add them to most views that display a Spotify album
- Refactor methods that need retries to do the retry outside of the function itself. This allows me to track the attempts to pull things in the server timing headers and makes the return types a lot looser.