### PR TITLE
Genre & Artist Searching Fixes

### DIFF
--- a/app/components/Album/ReviewButtons.tsx
+++ b/app/components/Album/ReviewButtons.tsx
@@ -40,7 +40,7 @@ const ReviewButtons: React.FC<ReviewButtonProps> = ({ item }) => {
             </Heading>
             <ButtonLinkGroup
               items={item.genres.slice(0, 3)}
-              keyFunction={(genre) => genre}
+              keyFunction={(genre, i) => `${genre}-${i}`}
               toFunction={(genre) => `/genre?genre=${genre}`}
               childFunction={(genre) => genre}
               className={clsx('btn-xs')}

--- a/app/components/Album/ReviewButtons.tsx
+++ b/app/components/Album/ReviewButtons.tsx
@@ -41,7 +41,7 @@ const ReviewButtons: React.FC<ReviewButtonProps> = ({ item }) => {
             <ButtonLinkGroup
               items={item.genres.slice(0, 3)}
               keyFunction={(genre, i) => `${genre}-${i}`}
-              toFunction={(genre) => `/genre?genre=${genre}`}
+              toFunction={(genre) => `/genre/${genre}`}
               childFunction={(genre) => genre}
               className={clsx('btn-xs')}
               wrapperClassName={clsx('mb-2')}

--- a/app/components/Base/ButtonLinkGroup.tsx
+++ b/app/components/Base/ButtonLinkGroup.tsx
@@ -4,9 +4,9 @@ import { ButtonLink, ButtonLinkProps } from '~/components/Base'
 
 interface Props<T extends any = any> extends Omit<ButtonLinkProps, 'to'> {
   items: T[]
-  keyFunction: (item: T) => string
-  toFunction: (item: T) => string
-  childFunction: (item: T) => string | React.ReactNode
+  keyFunction: (item: T, i: number) => string
+  toFunction: (item: T, i: number) => string
+  childFunction: (item: T, i: number) => string | React.ReactNode
   wrapperClassName?: string
 }
 
@@ -21,14 +21,14 @@ function ButtonLinkGroup<T extends any>({
 }: Props<T>) {
   return (
     <ButtonLinkGroupWrapper className={clsx(wrapperClassName)}>
-      {items.map((item) => (
+      {items.map((item, i) => (
         <ButtonLink
-          to={toFunction(item)}
-          key={keyFunction(item)}
+          to={toFunction(item, i)}
+          key={keyFunction(item, i)}
           className={clsx(className)}
           {...props}
         >
-          {childFunction(item)}
+          {childFunction(item, i)}
         </ButtonLink>
       ))}
     </ButtonLinkGroupWrapper>

--- a/app/context/UTMParameters.tsx
+++ b/app/context/UTMParameters.tsx
@@ -24,33 +24,17 @@ const UTMParametersProvider: React.FC<React.PropsWithChildren<{}>> = ({
     }
 
     const currentParams = new URLSearchParams(search.slice(1))
-    const [campaign, term] = pathname.split('/').filter(Boolean)
+    const [campaign, term, content] = pathname.split('/').filter(Boolean)
 
     if (!campaign) {
       return params
     }
 
     params.set('utm_campaign', campaign)
+    params.set('utm_term', term)
 
-    if (term) {
-      params.set('utm_term', term)
-    } else if (campaign === 'genre') {
-      const genre = currentParams.get('genre')
-
-      if (genre) {
-        params.set('utm_term', genre)
-      }
-    } else if (campaign === 'related-artist') {
-      const artistID = currentParams.get('artistID')
-      const artistName = currentParams.get('artist')
-
-      if (artistID) {
-        params.set('utm_term', 'artistID')
-        params.set('utm_content', artistID)
-      } else if (artistName) {
-        params.set('utm_term', 'artist')
-        params.set('utm_content', artistName)
-      }
+    if (content) {
+      params.set('utm_content', content)
     }
 
     const fromParam = currentParams.get('from')

--- a/app/hooks/tests/useUTM.test.tsx
+++ b/app/hooks/tests/useUTM.test.tsx
@@ -69,29 +69,29 @@ describe('useUTM', () => {
     },
     {
       it: 'genre',
-      url: 'https://album-mode.party/genre?genre=5th+wave+emo',
+      url: 'https://album-mode.party/genre/5th+wave+emo',
       params: {
         utm_campaign: 'genre',
-        utm_term: '5th wave emo',
+        utm_term: '5th+wave+emo',
       },
       embedURL: 'https://open.spotify.com/artist/0NvYpRJfbFyOI4QdsLJ1Jw',
     },
     {
       it: 'random genre',
-      url: 'https://album-mode.party/genre?genre=5th+wave+emo&from=random',
+      url: 'https://album-mode.party/genre/5th+wave+emo?from=random',
       params: {
         utm_campaign: 'genre',
-        utm_term: '5th wave emo',
+        utm_term: '5th+wave+emo',
         utm_medium: 'random',
       },
       embedURL: 'https://open.spotify.com/artist/0NvYpRJfbFyOI4QdsLJ1Jw',
     },
     {
       it: 'related artist by ID',
-      url: 'http://localhost:3000/related-artist?artistID=610dMJUjtyxC9ZrS30iZrX',
+      url: 'http://localhost:3000/spotify/artist-id/610dMJUjtyxC9ZrS30iZrX',
       params: {
-        utm_campaign: 'related-artist',
-        utm_term: 'artistID',
+        utm_campaign: 'spotify',
+        utm_term: 'artist-id',
         utm_content: '610dMJUjtyxC9ZrS30iZrX',
       },
       // Home Is Where Forever
@@ -99,11 +99,11 @@ describe('useUTM', () => {
     },
     {
       it: 'related artist by name',
-      url: 'http://localhost:3000/related-artist?artist=home%20is%20where',
+      url: 'http://localhost:3000/spotify/artist/home%20is%20where',
       params: {
-        utm_campaign: 'related-artist',
+        utm_campaign: 'spotify',
         utm_term: 'artist',
-        utm_content: 'home is where',
+        utm_content: encodeURIComponent('home is where'),
       },
     },
     {

--- a/app/lib/random.server.ts
+++ b/app/lib/random.server.ts
@@ -13,11 +13,11 @@ const getAction = async (spotifyClient: Spotify): Promise<string> => {
       return `/publication/${await db.getRandomPublication()}?from=play-me-something`
 
     case 'genre':
-      return `/genre?genre=${await db.getRandomTopGenre()}&from=play-me-something`
+      return `/genre/${await db.getRandomTopGenre()}?from=play-me-something`
 
     case 'artist':
       const artist = await spotifyClient.getRandomTopArtist()
-      return `/related-artist?artistID=${artist.id}&from=play-me-something`
+      return `/spotify/artist-id/${artist.id}?from=play-me-something`
 
     default:
       throw new Error(`unsupported option ${option}`)

--- a/app/lib/spotify.server.ts
+++ b/app/lib/spotify.server.ts
@@ -254,7 +254,7 @@ export class Spotify {
     let genres = artist.body.genres
 
     if (genres.length > 2) {
-      genres = [genres[0], ...sampleSize(genres, genres.length - 1)]
+      genres = [genres[0], ...sampleSize(genres.slice(1), genres.length - 1)]
     }
 
     return {

--- a/app/routes/genre/$genre.tsx
+++ b/app/routes/genre/$genre.tsx
@@ -1,0 +1,101 @@
+import { LoaderArgs, MetaFunction, json, redirect } from '@remix-run/node'
+import { useLoaderData } from '@remix-run/react'
+import retry from 'async-retry'
+import startCase from 'lodash/startCase'
+
+import { badRequest } from '~/lib/responses.server'
+import spotifyLib from '~/lib/spotify.server'
+import userSettings from '~/lib/userSettings.server'
+import wikipedia from '~/lib/wikipedia.server'
+
+import Album from '~/components/Album'
+import AlbumErrorBoundary, {
+  AlbumCatchBoundary,
+} from '~/components/Album/ErrorBoundary'
+import { Layout } from '~/components/Base'
+import WikipediaSummary from '~/components/WikipediaSummary'
+import config from '~/config'
+
+export async function loader({
+  request,
+  params,
+  context: { serverTiming, logger },
+}: LoaderArgs) {
+  const genre = params.genre
+
+  if (!genre) {
+    throw badRequest({
+      error: 'genre param must be provided to search via genre',
+      logger,
+    })
+  }
+
+  const spotify = await serverTiming.track('spotify.init', () =>
+    spotifyLib.initializeFromRequest(request)
+  )
+  const album = await retry(async (_, attempt) => {
+    const album = await serverTiming.track('spotify.fetch', () =>
+      spotify.getRandomAlbumByGenre(genre)
+    )
+    serverTiming.add({
+      label: 'attempts',
+      desc: `${attempt} Attempt(s)`,
+    })
+
+    return album
+  }, config.asyncRetryConfig)
+  const wiki = await serverTiming.track('wikipedia', () =>
+    wikipedia.getSummaryForAlbum({
+      album: album.name,
+      artist: album.artists[0].name,
+    })
+  )
+
+  return json(
+    {
+      album,
+      genre,
+      wiki,
+    },
+    {
+      headers: {
+        'Set-Cookie': await userSettings.setLastPresented({
+          request,
+          lastPresented: album.id,
+        }),
+        [serverTiming.headerKey]: serverTiming.toString(),
+      },
+    }
+  )
+}
+
+export const ErrorBoundary = AlbumErrorBoundary
+export const CatchBoundary = AlbumCatchBoundary
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data) {
+    return {}
+  }
+
+  const genre = startCase(data.genre)
+
+  return {
+    title: `${genre} | ${config.siteTitle}`,
+    description: `Discover new music from the ${genre} genre on Spotify!`,
+  }
+}
+
+export default function GenreSearch() {
+  const data = useLoaderData<typeof loader>()
+
+  const { album, genre } = data
+
+  if (!album?.external_urls?.spotify) {
+    return null
+  }
+
+  return (
+    <Layout headerBreadcrumbs={['Genre', genre]}>
+      <Album album={album} footer={<WikipediaSummary summary={data.wiki} />} />
+    </Layout>
+  )
+}

--- a/app/routes/genre/index.tsx
+++ b/app/routes/genre/index.tsx
@@ -1,106 +1,17 @@
-import { LoaderArgs, MetaFunction, json, redirect } from '@remix-run/node'
-import { useLoaderData } from '@remix-run/react'
-import retry from 'async-retry'
-import startCase from 'lodash/startCase'
+import { LoaderArgs, redirect } from '@remix-run/node'
 
 import { badRequest } from '~/lib/responses.server'
-import spotifyLib from '~/lib/spotify.server'
-import userSettings from '~/lib/userSettings.server'
-import wikipedia from '~/lib/wikipedia.server'
 
-import Album from '~/components/Album'
-import AlbumErrorBoundary, {
-  AlbumCatchBoundary,
-} from '~/components/Album/ErrorBoundary'
-import { Layout } from '~/components/Base'
-import WikipediaSummary from '~/components/WikipediaSummary'
-import config from '~/config'
-
-export async function loader({
-  request,
-  context: { serverTiming, logger },
-}: LoaderArgs) {
-  const settings = await userSettings.get(request)
+export async function loader({ request, context: { logger } }: LoaderArgs) {
   const url = new URL(request.url)
   const genre = url.searchParams.get('genre')
 
   if (!genre) {
-    if (settings.lastSearchType === 'genre' && settings.lastSearchTerm) {
-      return redirect(`/genre?genre=${genre}`)
-    }
-
     throw badRequest({
       error: 'genre query param must be provided to search via genre',
       logger,
     })
   }
 
-  const spotify = await serverTiming.track('spotify.init', () =>
-    spotifyLib.initializeFromRequest(request)
-  )
-  const album = await retry(async (_, attempt) => {
-    const album = await serverTiming.track('spotify.fetch', () =>
-      spotify.getRandomAlbumByGenre(genre)
-    )
-    serverTiming.add({
-      label: 'attempts',
-      desc: `${attempt} Attempt(s)`,
-    })
-
-    return album
-  }, config.asyncRetryConfig)
-  const wiki = await serverTiming.track('wikipedia', () =>
-    wikipedia.getSummaryForAlbum({
-      album: album.name,
-      artist: album.artists[0].name,
-    })
-  )
-
-  return json(
-    {
-      album,
-      genre,
-      wiki,
-    },
-    {
-      headers: {
-        'Set-Cookie': await userSettings.setLastPresented({
-          request,
-          lastPresented: album.id,
-        }),
-        [serverTiming.headerKey]: serverTiming.toString(),
-      },
-    }
-  )
-}
-
-export const ErrorBoundary = AlbumErrorBoundary
-export const CatchBoundary = AlbumCatchBoundary
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  if (!data) {
-    return {}
-  }
-
-  const genre = startCase(data.genre)
-
-  return {
-    title: `${genre} | ${config.siteTitle}`,
-    description: `Discover new music from the ${genre} genre on Spotify!`,
-  }
-}
-
-export default function GenreSearch() {
-  const data = useLoaderData<typeof loader>()
-
-  const { album, genre } = data
-
-  if (!album?.external_urls?.spotify) {
-    return null
-  }
-
-  return (
-    <Layout headerBreadcrumbs={['Genre', genre]}>
-      <Album album={album} footer={<WikipediaSummary summary={data.wiki} />} />
-    </Layout>
-  )
+  return redirect(`/genre/${genre}`)
 }

--- a/app/routes/genre/random.tsx
+++ b/app/routes/genre/random.tsx
@@ -4,5 +4,5 @@ import db from '~/lib/db.server'
 
 export async function loader() {
   const genre = await db.getRandomGenre()
-  return redirect(`/genre?genre=${genre}&from=random`)
+  return redirect(`/genre/${genre}?from=random`)
 }

--- a/app/routes/genres.tsx
+++ b/app/routes/genres.tsx
@@ -31,7 +31,7 @@ export default function Genres() {
         <GenreSearchForm />
         <ButtonLinkGroup
           items={data.topGenres}
-          toFunction={(genre) => `/genre?genre=${genre}`}
+          toFunction={(genre) => `/genre/${genre}`}
           keyFunction={(genre) => genre}
           childFunction={(genre) => genre}
           wrapperClassName={clsx('mt-4')}

--- a/app/routes/related-artist/index.tsx
+++ b/app/routes/related-artist/index.tsx
@@ -1,154 +1,20 @@
-import { LoaderArgs, MetaFunction, json, redirect } from '@remix-run/node'
-import { useLoaderData } from '@remix-run/react'
-import retry from 'async-retry'
-import promiseHash from 'promise-hash'
-import { badRequest, serverError } from 'remix-utils'
+import { LoaderArgs, redirect } from '@remix-run/node'
 
-import spotifyLib from '~/lib/spotify.server'
-import userSettings from '~/lib/userSettings.server'
-import wikipedia from '~/lib/wikipedia.server'
+import { badRequest } from '~/lib/responses.server'
 
-import Album from '~/components/Album'
-import AlbumErrorBoundary, {
-  AlbumCatchBoundary,
-} from '~/components/Album/ErrorBoundary'
-import { Layout } from '~/components/Base'
-import WikipediaSummary from '~/components/WikipediaSummary'
-import config from '~/config'
-import env from '~/env.server'
-
-export async function loader({
-  request,
-  context: { serverTiming, logger },
-}: LoaderArgs) {
+export async function loader({ request, context: { logger } }: LoaderArgs) {
   const url = new URL(request.url)
-  const settings = await userSettings.get(request)
-  let artistParam = url.searchParams.get('artist')
+  const artist = url.searchParams.get('artist')
   const artistID = url.searchParams.get('artistID')
-  const spotify = await serverTiming.track('spotify.init', () =>
-    spotifyLib.initializeFromRequest(request)
-  )
-  let album:
-    | Awaited<ReturnType<(typeof spotify)['getRandomAlbumForArtistByID']>>
-    | undefined
-  let artist: SpotifyApi.ArtistObjectFull | undefined
 
-  if (artistParam) {
-    let searchMethod = spotify.getRandomAlbumForRelatedArtist
-
-    // If the search term is quoted, get random album for just that artist
-    if (artistParam.startsWith('"') && artistParam.endsWith('"')) {
-      searchMethod = spotify.getRandomAlbumForArtist
-    }
-
-    album = await serverTiming.track('spotify.fetch', () =>
-      searchMethod(artistParam as string)
-    )
-    artist = album.artists[0]
+  if (artist) {
+    return redirect(`/spotify/artist/${artist}`)
   } else if (artistID) {
-    const resp = await retry(async (_, attempt) => {
-      const resp = await promiseHash({
-        album: serverTiming.track('spotify.albumFetch', () =>
-          spotify.getRandomAlbumForRelatedArtistByID(artistID)
-        ),
-        artist: serverTiming.track('spotify.artistFetch', () =>
-          spotify.getArtistByID(artistID)
-        ),
-      })
-      serverTiming.add({
-        label: 'attempts',
-        desc: `${attempt} Attempt(s)`,
-      })
-
-      return resp
-    }, config.asyncRetryConfig)
-    album = resp.album
-    artist = resp.artist
-  } else {
-    if (
-      settings.lastSearchTerm &&
-      (settings.lastSearchType === 'artist' ||
-        settings.lastSearchType === 'artistID')
-    ) {
-      return redirect(
-        `/related-artist?${settings.lastSearchType}=${settings.lastSearchTerm}`
-      )
-    }
-
-    throw badRequest({
-      error: 'artist OR artistID query param must be provided',
-      logger,
-    })
+    return redirect(`/spotify/artist-id/${artistID}`)
   }
 
-  const wiki = await serverTiming.track('wikipedia', () => {
-    if (!album) {
-      throw serverError(
-        {
-          error: 'could not fetch album',
-          logger,
-        },
-        { headers: serverTiming.headers() }
-      )
-    }
-
-    return wikipedia.getSummaryForAlbum({
-      album: album.name,
-      artist: album.artists[0].name,
-    })
+  throw badRequest({
+    error: 'either artist or artistID must be provided as a query parameter',
+    logger,
   })
-
-  return json(
-    {
-      album,
-      artist,
-      wiki,
-    },
-    {
-      headers: {
-        'Set-Cookie': await userSettings.setLastPresented({
-          request,
-          lastPresented: album.id,
-        }),
-        [serverTiming.headerKey]: serverTiming.toString(),
-      },
-    }
-  )
-}
-
-export const ErrorBoundary = AlbumErrorBoundary
-export const CatchBoundary = AlbumCatchBoundary
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  if (!data) {
-    return {}
-  }
-
-  const title = `Discover music similar to ${data.artist.name}`
-  const description = `We think that you might like ${data.album.artists[0].name}`
-  const ogImage = `${env.OG_API_URL}/api/artist/${data.artist.id}`
-
-  return {
-    title: `${title} | ${config.siteTitle}`,
-    description,
-    'og:title': title,
-    'og:description': description,
-    'og:image': ogImage,
-    'twitter:card': 'summary_large_image',
-    'twitter:title': title,
-    'twitter:description': description,
-    'twitter:image': ogImage,
-  }
-}
-
-export default function RelatedArtistSearch() {
-  const data = useLoaderData<typeof loader>()
-
-  return (
-    <Layout headerBreadcrumbs={['Artist', data.artist.name ?? '']}>
-      <Album
-        album={data.album}
-        footer={<WikipediaSummary summary={data.wiki} />}
-      />
-    </Layout>
-  )
 }

--- a/app/routes/spotify/artist-id/$artistID.tsx
+++ b/app/routes/spotify/artist-id/$artistID.tsx
@@ -1,0 +1,124 @@
+import { LoaderArgs, MetaFunction, json, redirect } from '@remix-run/node'
+import { useLoaderData } from '@remix-run/react'
+import retry from 'async-retry'
+import promiseHash from 'promise-hash'
+import { badRequest, serverError } from 'remix-utils'
+
+import spotifyLib from '~/lib/spotify.server'
+import userSettings from '~/lib/userSettings.server'
+import wikipedia from '~/lib/wikipedia.server'
+
+import Album from '~/components/Album'
+import AlbumErrorBoundary, {
+  AlbumCatchBoundary,
+} from '~/components/Album/ErrorBoundary'
+import { Layout } from '~/components/Base'
+import WikipediaSummary from '~/components/WikipediaSummary'
+import config from '~/config'
+import env from '~/env.server'
+
+export async function loader({
+  request,
+  params,
+  context: { serverTiming, logger },
+}: LoaderArgs) {
+  const artistID = params.artistID
+  const spotify = await serverTiming.track('spotify.init', () =>
+    spotifyLib.initializeFromRequest(request)
+  )
+
+  if (!artistID) {
+    throw badRequest({
+      error: 'artistID must be provided as route param',
+      logger,
+    })
+  }
+
+  const { album, artist } = await retry(async (_, attempt) => {
+    const resp = await promiseHash({
+      album: serverTiming.track('spotify.albumFetch', () =>
+        spotify.getRandomAlbumForRelatedArtistByID(artistID)
+      ),
+      artist: serverTiming.track('spotify.artistFetch', () =>
+        spotify.getArtistByID(artistID)
+      ),
+    })
+    serverTiming.add({
+      label: 'attempts',
+      desc: `${attempt} Attempt(s)`,
+    })
+
+    return resp
+  }, config.asyncRetryConfig)
+
+  const wiki = await serverTiming.track('wikipedia', () => {
+    if (!album) {
+      throw serverError(
+        {
+          error: 'could not fetch album',
+          logger,
+        },
+        { headers: serverTiming.headers() }
+      )
+    }
+
+    return wikipedia.getSummaryForAlbum({
+      album: album.name,
+      artist: album.artists[0].name,
+    })
+  })
+
+  return json(
+    {
+      album,
+      artist,
+      wiki,
+    },
+    {
+      headers: {
+        'Set-Cookie': await userSettings.setLastPresented({
+          request,
+          lastPresented: album.id,
+        }),
+        [serverTiming.headerKey]: serverTiming.toString(),
+      },
+    }
+  )
+}
+
+export const ErrorBoundary = AlbumErrorBoundary
+export const CatchBoundary = AlbumCatchBoundary
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data) {
+    return {}
+  }
+
+  const title = `Discover music similar to ${data.artist.name}`
+  const description = `We think that you might like ${data.album.artists[0].name}`
+  const ogImage = `${env.OG_API_URL}/api/artist/${data.artist.id}`
+
+  return {
+    title: `${title} | ${config.siteTitle}`,
+    description,
+    'og:title': title,
+    'og:description': description,
+    'og:image': ogImage,
+    'twitter:card': 'summary_large_image',
+    'twitter:title': title,
+    'twitter:description': description,
+    'twitter:image': ogImage,
+  }
+}
+
+export default function RelatedArtistSearch() {
+  const data = useLoaderData<typeof loader>()
+
+  return (
+    <Layout headerBreadcrumbs={['Artist', data.artist.name ?? '']}>
+      <Album
+        album={data.album}
+        footer={<WikipediaSummary summary={data.wiki} />}
+      />
+    </Layout>
+  )
+}

--- a/app/routes/spotify/artist/$artist.tsx
+++ b/app/routes/spotify/artist/$artist.tsx
@@ -1,0 +1,119 @@
+import { LoaderArgs, MetaFunction, json, redirect } from '@remix-run/node'
+import { useLoaderData } from '@remix-run/react'
+import retry from 'async-retry'
+import promiseHash from 'promise-hash'
+import { badRequest, serverError } from 'remix-utils'
+
+import spotifyLib from '~/lib/spotify.server'
+import userSettings from '~/lib/userSettings.server'
+import wikipedia from '~/lib/wikipedia.server'
+
+import Album from '~/components/Album'
+import AlbumErrorBoundary, {
+  AlbumCatchBoundary,
+} from '~/components/Album/ErrorBoundary'
+import { Layout } from '~/components/Base'
+import WikipediaSummary from '~/components/WikipediaSummary'
+import config from '~/config'
+import env from '~/env.server'
+
+export async function loader({
+  request,
+  params,
+  context: { serverTiming, logger },
+}: LoaderArgs) {
+  const url = new URL(request.url)
+  const settings = await userSettings.get(request)
+  const spotify = await spotifyLib.initializeFromRequest(request)
+  let artistParam = params.artist
+
+  if (!artistParam) {
+    throw badRequest({
+      error: 'artist name must be provided as a route param',
+      logger,
+    })
+  }
+
+  let searchMethod = spotify.getRandomAlbumForRelatedArtist
+
+  // If the search term is quoted, get random album for just that artist
+  if (artistParam.startsWith('"') && artistParam.endsWith('"')) {
+    searchMethod = spotify.getRandomAlbumForArtist
+  }
+
+  const album = await serverTiming.track('spotify.fetch', () =>
+    searchMethod(artistParam as string)
+  )
+  const artist = album.artists[0]
+
+  const wiki = await serverTiming.track('wikipedia', () => {
+    if (!album) {
+      throw serverError(
+        {
+          error: 'could not fetch album',
+          logger,
+        },
+        { headers: serverTiming.headers() }
+      )
+    }
+
+    return wikipedia.getSummaryForAlbum({
+      album: album.name,
+      artist: album.artists[0].name,
+    })
+  })
+
+  return json(
+    {
+      album,
+      artist,
+      wiki,
+    },
+    {
+      headers: {
+        'Set-Cookie': await userSettings.setLastPresented({
+          request,
+          lastPresented: album.id,
+        }),
+        [serverTiming.headerKey]: serverTiming.toString(),
+      },
+    }
+  )
+}
+
+export const ErrorBoundary = AlbumErrorBoundary
+export const CatchBoundary = AlbumCatchBoundary
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data) {
+    return {}
+  }
+
+  const title = `Discover music similar to ${data.artist.name}`
+  const description = `We think that you might like ${data.album.artists[0].name}`
+  const ogImage = `${env.OG_API_URL}/api/artist/${data.artist.id}`
+
+  return {
+    title: `${title} | ${config.siteTitle}`,
+    description,
+    'og:title': title,
+    'og:description': description,
+    'og:image': ogImage,
+    'twitter:card': 'summary_large_image',
+    'twitter:title': title,
+    'twitter:description': description,
+    'twitter:image': ogImage,
+  }
+}
+
+export default function RelatedArtistSearch() {
+  const data = useLoaderData<typeof loader>()
+
+  return (
+    <Layout headerBreadcrumbs={['Artist', data.artist.name ?? '']}>
+      <Album
+        album={data.album}
+        footer={<WikipediaSummary summary={data.wiki} />}
+      />
+    </Layout>
+  )
+}


### PR DESCRIPTION
- Move genre and artist result pages to routes where the identifier is coming from path parameters instead of query parameters. This fixes an issue where remix-auth will randomly drop query parameters when it refreshes the access token.
- Fix issue where genre badges were showing up multiple times